### PR TITLE
GitHub actions CI workflow improvements

### DIFF
--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -20,4 +20,4 @@ jobs:
       run: composer run-script stan
 
     - name: Run test suite
-      run: COMPOSER_PROCESS_TIMEOUT=600 composer run-script test
+      run: composer run-script test -- --stop-on-failure

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -13,8 +13,8 @@ jobs:
 
     - uses: "ramsey/composer-install@v1"
 
-    - name: Run linting
-      run: composer run-script check-style
+    # - name: Run linting
+    #   run: composer run-script check-style
 
     - name: Run static analysis
       run: composer run-script stan

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -11,11 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Validate composer.json
-      run: composer validate
-
-    - name: Install dependencies
-      run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
+    - uses: "ramsey/composer-install@v1"
 
     - name: Run linting
       run: composer run-script check-style

--- a/.github/workflows/actions-ci.yml
+++ b/.github/workflows/actions-ci.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Add ability to skip CI if commit message contains `[skip-ci]`
- Simplify composer install CI command by using `ramsey/composer-install@v1` action
- Improved test step command for CI
- Comment out lint step in CI